### PR TITLE
Look up z3 executable in environment

### DIFF
--- a/z3-mode.el
+++ b/z3-mode.el
@@ -35,7 +35,7 @@
   :group 'languages
   :prefix "z3-")
 
-(defcustom z3-solver-cmd "/home/zv/Development/z3/build/z3"
+(defcustom z3-solver-cmd "/bin/env z3"
   "The command used when you run the solver.
 
 The following solvers are currently supported


### PR DESCRIPTION
The default location for the z3 solver is currently hardcoded to a location in
@zv's system. This suggests, instead, looking up the executable from the
users environment.

This configuration is working on my system.