### PR TITLE
Autoload auto-mode-alist update

### DIFF
--- a/z3-mode.el
+++ b/z3-mode.el
@@ -164,6 +164,7 @@ The default executable is %S." z3-solver-cmd)
   '((error "error \"line " line " column " column ": " (message) "\")"))
   :modes 'z3-mode)
 
+;;;###autoload
 (setq auto-mode-alist
       (append
        '(("\\.smt[2]?$" . z3-mode)) auto-mode-alist))


### PR DESCRIPTION
This allows people who defer the loading of z3-mode to continue to
have smt files open with z3-mode.